### PR TITLE
feat: add `is_nan` to math stdlib

### DIFF
--- a/crates/cli/tests/scripts/is_nan.gml
+++ b/crates/cli/tests/scripts/is_nan.gml
@@ -1,0 +1,21 @@
+var z = 0;
+assert(is_nan(z / z));
+assert(is_nan(0 * infinity));
+assert(is_nan(infinity - infinity));
+assert(is_nan(infinity / infinity));
+assert(is_nan(power(-2, 0.5)));
+assert(!is_nan(infinity));
+assert(!is_nan(-infinity));
+assert(!is_nan(0));
+assert(!is_nan(-0));
+assert(!is_nan(1.5));
+assert(!is_nan("5"));
+assert(!is_nan("5.5"));
+assert(is_nan("NaN")); // note: GM actually disagrees with this, which is presumably a bug
+assert(is_nan("hello"));
+assert(is_nan(undefined));
+assert(is_nan([]));
+assert(is_nan({}));
+assert(is_nan(function() {}));
+
+return true;

--- a/crates/stdlib/src/math.rs
+++ b/crates/stdlib/src/math.rs
@@ -381,6 +381,16 @@ pub fn radtodeg<'gc>(_ctx: vm::Context<'gc>, input: f64) -> Result<f64, Infallib
     Ok(input.to_degrees())
 }
 
+/// Returns if the provided input is NaN. 
+/// 
+/// GameMaker is consistent with IEEE when dealing with actual floats. It'll attempt to coerce a
+/// a float per its typical rules, but for anything it cannot coerce it returns _true_.
+/// 
+/// See `crates/cli/tests/scripts/is_nan.gml` for more.
+pub fn is_nan<'gc>(ctx: vm::Context<'gc>, input: vm::Value<'gc>) -> Result<bool, Infallible> {
+    Ok(input.coerce_float(ctx).is_none_or(f64::is_nan))
+}
+
 pub fn math_lib<'gc>(ctx: vm::Context<'gc>, lib: &mut vm::MagicSet<'gc>) {
     lib.insert_constant(ctx, "NaN", f64::NAN);
     lib.insert_constant(ctx, "infinity", f64::INFINITY);
@@ -419,4 +429,5 @@ pub fn math_lib<'gc>(ctx: vm::Context<'gc>, lib: &mut vm::MagicSet<'gc>) {
     lib.insert_callback(ctx, "arctan2", arctan2);
     lib.insert_callback(ctx, "degtorad", degtorad);
     lib.insert_callback(ctx, "radtodeg", radtodeg);
+    lib.insert_callback(ctx, "is_nan", is_nan);
 }


### PR DESCRIPTION
Adds the GML equivalent for [`is_nan`](https://manual.gamemaker.io/monthly/en/GameMaker_Language/GML_Reference/Variable_Functions/is_nan.htm). Follows the behavior found when tested in GM: any value that can be successfully coerced into a non-NaN float yields `false`, while anything else (including non-integers) yields `true`. 

The only deviation is what is presumably a bug in GM, which considers `is_nan("NaN")` to be false. This implementation will return `true`.